### PR TITLE
FilterQueryBuilder.build: clone params object

### DIFF
--- a/src/lib/FilterQueryBuilder.ts
+++ b/src/lib/FilterQueryBuilder.ts
@@ -84,7 +84,7 @@ export default class FilterQueryBuilder<
   }
 
   build(params: FilterQueryParams = {}): QueryBuilder<M> {
-    const { fields, limit, offset, order, eager } = params;
+    const { fields, limit, offset, order, eager } = Object.assign({}, params);
 
     applyWhere(params.where, this._builder, this.utils);
     applyRequire(params.require, this._builder, this.utils);


### PR DESCRIPTION
If you consecutively initialize two `buildQuery(...).build(filter)` calls, and debug the `filter` object in-between the two runs, will be cleared. (unsure by what cause / which apply sub fn)

Cloning the object ensures the reference is disconnected, and the original variable won't be modified